### PR TITLE
Add support for systems with faulty PAPI modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,15 @@ endif
 
 LIBS :=
 ifneq (,$(findstring PAPI,$(BUILD_FLAGS)))
+	ifeq ($(COMPILER),gnu)
+        ifdef PAPI_INCLUDE_PATH
+    		INCLUDES += -I$(PAPI_INCLUDE_PATH)
+        endif
+	else ifeq ($(COMPILER),cray)
+        ifdef PAPI_LIB_PATH
+    		LIBS += -L$(PAPI_LIB_PATH)
+        endif
+	endif
 	LIBS += -lpapi -lpfm
 endif
 
@@ -188,7 +197,7 @@ SOURCES = src/euler3d_cpu_double.cpp \
 OBJECTS     := $(patsubst src/%.cpp, $(OBJ_DIR)/%.o,     $(SOURCES))
 OBJECTS_DBG := $(patsubst src/%.cpp, $(OBJ_DIR_DBG)/%.o, $(SOURCES))
 
-INCLUDES := -Isrc -Isrc/Base -Isrc/Kernels -Isrc/Monitoring
+INCLUDES += -Isrc -Isrc/Base -Isrc/Kernels -Isrc/Monitoring -Isrc/Meshing
 
 #############
 ## TARGETS ##


### PR DESCRIPTION
Set env vars PAPI_LIB_PATH and PAPI_INCLUDE_PATH to tell Makefile where PAPI is installed.